### PR TITLE
dumpstats modification to go with nciaccountapi branch in ncigrafana

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,9 @@ git pull
 # Run doit with the default dodo.py script. Use a bunch
 # of threads to speed it up. Select just the dump_SU and
 # dump_storage tasks
-doit -n 4 -P thread dump_SU dump_lquota dump_storage
+#doit -n 4 -P thread dump_SU dump_lquota dump_storage
+### Don't need dump_storage any more
+doit -n 4 -P thread dump_SU dump_lquota
 
 # Split the upload into a separate call using a single thread
 # doit start_tunnel upload_storage upload_usage

--- a/run.sh
+++ b/run.sh
@@ -14,9 +14,7 @@ git pull
 # Run doit with the default dodo.py script. Use a bunch
 # of threads to speed it up. Select just the dump_SU and
 # dump_storage tasks
-#doit -n 4 -P thread dump_SU dump_lquota dump_storage
-### Don't need dump_storage any more
-doit -n 4 -P thread dump_SU dump_lquota
+doit -n 4 -P thread dump_SU dump_lquota dump_storage
 
 # Split the upload into a separate call using a single thread
 # doit start_tunnel upload_storage upload_usage


### PR DESCRIPTION
Modification to dumpstats to use the updated parse_user_storage_data in ncigrafana/nciaccountapi branch. Removes dump_storage step and runs upload_storage once per mount instead of once per project per mount.